### PR TITLE
Refine module 3 analytics framing and demo

### DIFF
--- a/docs/course-content.html
+++ b/docs/course-content.html
@@ -81,16 +81,16 @@
               </article>
               <article class="content-card">
                 <span class="tag">Barrie Robison</span>
-                <h3>Reproducibility, accuracy, and putting it to work</h3>
+                <h3>Accuracy, reproducibility, and provenance</h3>
                 <p>
-                  Context engineering, Promptulus and Vandalizer demos,
-                  evaluation, and deciding what to automate, augment,
-                  or leave alone.
+                  Practical strategies for evaluating AI output,
+                  checking reproducibility, and tracing provenance
+                  before results enter a workflow.
                 </p>
                 <ul style="font-size:0.85rem; color:var(--muted); margin-top:0.75rem; padding-left:1.2em;">
-                  <li>Choose the right layer of context for the job</li>
-                  <li>Verify AI output before it enters a workflow</li>
-                  <li>Decide what to automate, augment, or leave alone</li>
+                  <li>Evaluate AI output for accuracy before using it</li>
+                  <li>Check whether results are reproducible across runs</li>
+                  <li>Track provenance so outputs can be audited and trusted</li>
                 </ul>
                 <div class="card-actions">
                   <a class="button" href="slides-putting-it-to-work.html">Open module</a>

--- a/docs/module-context-layers.html
+++ b/docs/module-context-layers.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#191919" />
-    <title>Context Layers Module | AI4RA Workshop</title>
+    <title>Accuracy, Reproducibility, and Provenance Module | AI4RA Workshop</title>
     <meta
       name="description"
-      content="Facilitator-ready workshop module on layers of context engineering for AI4RA REACH 2026."
+      content="Facilitator-ready workshop module on evaluating AI output for accuracy, reproducibility, provenance, and institutional fit for AI4RA REACH 2026."
     />
     <link rel="stylesheet" href="styles.css" />
   </head>
@@ -37,13 +37,14 @@
         <section class="page-intro reveal">
           <div class="page-intro-panel">
             <img class="module-headshot" src="img/presenters/barrie-robison.jpg" alt="Barrie Robison" />
-            <p class="eyebrow">Module 3 — Led by Barrie Robison</p>
-            <h1>Your institutional data is already layered.</h1>
+            <p class="eyebrow">Module 3 - Led by Barrie Robison</p>
+            <h1>Accuracy, reproducibility, and provenance.</h1>
             <p class="section-copy">
-              Context engineering is how AI meets institutional information
-              where it actually lives: prompts, files, tools, retrieved
-              sources, structured data, and the human review boundaries around
-              them.
+              This module helps participants decide whether AI output is
+              trustworthy enough to use. The arc moves from evaluation across
+              the data lifecycle to reproducibility testing, provenance checks,
+              and the final decision about what to automate, augment, or leave
+              alone.
             </p>
             <div class="hero-actions">
               <a class="button" href="course-content.html">Back to course hub</a>
@@ -65,194 +66,213 @@
 
         <section id="overview" class="content-block reveal">
           <p class="eyebrow">Module brief</p>
-          <h2 class="section-heading section-heading-wide">Help participants choose the right layer for the job.</h2>
+          <h2 class="section-heading section-heading-wide">Help participants decide whether AI output can be trusted.</h2>
           <div class="compact-grid">
             <article class="content-card">
               <span class="tag">Learning goal</span>
-              <h3>Choose the layer that fits the workflow</h3>
+              <h3>Evaluate output before it enters a workflow</h3>
               <p>
-                Participants should be able to describe the major context
-                layers, explain what each one adds, and decide when a workflow
-                needs retrieval, tools, templates, or human escalation.
+                Participants should be able to define accuracy for a task,
+                explain where reproducibility can fail, and require provenance
+                before anyone acts on AI-generated output.
               </p>
             </article>
             <article class="content-card">
               <span class="tag">In-room move</span>
-              <h3>Teach from familiar data integration problems</h3>
+              <h3>Teach from familiar analytics and extraction tasks</h3>
               <p>
-                Use analytics pipelines, research metrics reporting, and
-                cross-system data integration as the bridge to prompt layers,
-                files, tools, and structured retrieval.
+                Use document extraction, search, synthesis, and reporting
+                examples from the earlier sessions so evaluation feels like an
+                extension of work they already do.
               </p>
             </article>
             <article class="content-card">
               <span class="tag">Participant artifact</span>
-              <h3>A context stack map</h3>
+              <h3>An evaluation plan for one workflow</h3>
               <p>
-                The main reusable output is a simple map of the layers a real
-                workflow needs now, plus which ones are unsafe or unnecessary.
+                The main reusable output is a short plan naming the ground
+                truth, replication strategy, provenance requirement, and human
+                review threshold for a workflow they care about.
               </p>
             </article>
             <article class="content-card">
               <span class="tag">Derived assets</span>
-              <h3>Context layers slide deck and future worksheet</h3>
+              <h3>Slide deck, Vandalizer exercises, and provenance example</h3>
               <p>
-                The current slide deck should be read as a condensed version of
-                this module's framing, stack definition, example, and activity.
+                The current slide deck is a condensed version of this module's
+                evaluation framing, extraction experiments, provenance
+                activity, and adoption decision framework.
               </p>
             </article>
             <article class="content-card">
               <span class="tag">Learning objectives</span>
               <h3>What participants should leave able to do</h3>
               <ul class="module-points">
-                <li>Choose the right layer of context for the job — map the context stack and use the thinnest layer that solves the problem reliably.</li>
-                <li>Verify AI output before it enters a workflow — apply reproducibility, accuracy, and trust checks to AI-generated outputs.</li>
-                <li>Decide what to automate, augment, or leave alone — classify institutional tasks by AI suitability and recognize when existing tools are the better answer.</li>
+                <li>Measure accuracy against ground truth, schema expectations, or another authoritative source instead of trusting fluent output.</li>
+                <li>Check reproducibility by rerunning workflows and comparing outputs across controlled variations.</li>
+                <li>Require provenance and human review before high-stakes answers enter institutional workflows.</li>
+                <li>Decide what to automate, augment, or leave alone based on auditability and risk.</li>
               </ul>
             </article>
           </div>
 
           <article class="course-module module-full module-lead">
             <span class="tag">Lecture framing</span>
-            <h3>Start with the data they already manage, not the magic</h3>
+            <h3>Start with trust, not tool enthusiasm</h3>
             <p>
-              A practical way to teach this module is to connect to what the
-              audience already knows: they spend their days integrating data
-              from siloed systems into dashboards and reports. Context
-              engineering is the same challenge applied to AI, with each layer
-              improving capability in a different way and creating its own
-              review obligations.
+              A practical opening is to remind the audience that AI can help
+              with extraction, cleaning, search, and synthesis, but each phase
+              fails differently. The question is not whether the model can do
+              something interesting. The question is what evidence would make
+              the output trustworthy enough to use here.
             </p>
           </article>
         </section>
 
         <section id="teaching-flow" class="content-block reveal">
           <p class="eyebrow">Core teaching arc</p>
-          <h2 class="section-heading">Each layer changes both capability and risk.</h2>
+          <h2 class="section-heading">Move from lifecycle risk to practical trust checks.</h2>
           <div class="module-grid">
             <article class="course-module">
-              <span class="tag">Module explanation</span>
-              <h3>Prompting is only one layer in the stack</h3>
+              <span class="tag">Lifecycle framing</span>
+              <h3>Every phase has its own failure modes</h3>
               <p>
-                Adding a role prompt can improve tone and framing. Adding
-                examples can improve consistency. Adding files and retrieval can
-                improve grounding. Adding tools can make the workflow act on the
-                world. Every new layer expands both what the system can do and
-                what the team must validate.
+                Extraction can hallucinate fields, cleaning can drop valid
+                records, search can miss relevant items, and synthesis can
+                smooth over uncertainty. Trust requires evaluation moves that
+                fit the phase, not a single generic quality check.
               </p>
             </article>
 
             <article class="course-module">
-              <span class="tag">The layers</span>
-              <h3>A context stack participants can remember</h3>
+              <span class="tag">Evaluation moves</span>
+              <h3>Accuracy needs a definition</h3>
               <ul class="module-points">
-                <li>System or role instructions that define the model's job and boundaries.</li>
-                <li>Task prompts that describe the immediate assignment.</li>
-                <li>Examples or templates that show the expected format and tone.</li>
-                <li>Files, images, or documents that provide direct reference material.</li>
-                <li>Tools and actions such as search, code, SQL, or workflow integrations.</li>
-                <li>Retrieved and structured institutional data that grounds answers in current sources.</li>
+                <li>Compare outputs to known correct answers or another authoritative source.</li>
+                <li>Use sampling and automated consistency checks when scale makes full review impossible.</li>
+                <li>Match the amount of validation to the stakes of the workflow.</li>
+                <li>Teach participants to distrust confidence and look for evidence.</li>
               </ul>
             </article>
 
             <article class="course-module">
-              <span class="tag">Research analytics lens</span>
-              <h3>Why layered context fits analytics work</h3>
+              <span class="tag">Reproducibility and guardrails</span>
+              <h3>OCR, schemas, and replication reveal instability</h3>
               <p>
-                Research analytics work mixes data from eRA platforms,
-                institutional dashboards, HERD submissions, publication
-                databases, and local spreadsheets. A layered approach lets
-                teams decide whether the job needs only better instructions,
-                a trusted template, a reference data set, a SQL query against
-                the data warehouse, or a human escalation rule.
+                OCR quality sets the ceiling, data models catch structural
+                errors, structured outputs reduce format drift, and repeated
+                runs expose variability that a single successful demo hides.
               </p>
             </article>
 
             <article class="course-module">
-              <span class="tag">Teaching takeaway</span>
-              <h3>Use the thinnest layer that gets the job done</h3>
+              <span class="tag">Provenance and institutional fit</span>
+              <h3>Ask where the answer came from and whether it can be audited</h3>
               <p>
-                If a better prompt and a template produce reliable output, they
-                may not need retrieval. If a current policy PDF is enough, they
-                may not need a live database connection. If an answer depends
-                on institution-specific judgment, the right layer may be an
-                escalation rule instead of more automation.
+                Participants should expect traceability for extracted
+                requirements and use the automate, augment, or leave-alone
+                framework when auditability is missing or the stakes are high.
               </p>
             </article>
           </div>
 
           <article class="course-module module-full">
             <span class="tag">Suggested teaching flow</span>
-            <h3>A sequence for presenting the stack</h3>
+            <h3>A sequence that matches the current deck</h3>
             <ol class="module-points">
-              <li>Start with a plain-language definition: context is everything the model can rely on while doing the task.</li>
-              <li>Show that a prompt is only one layer in a broader design stack.</li>
-              <li>Walk through the major layers from lightest to heaviest.</li>
-              <li>Explain what each layer is good at and where it introduces new failure modes.</li>
-              <li>Emphasize that teams should use the thinnest layer that solves the problem reliably.</li>
-              <li>Close by connecting layered context to evaluation, governance, and human review.</li>
+              <li>Open with the research analytics lifecycle and ask how each phase can fail.</li>
+              <li>Define evaluation and emphasize authoritative sources rather than fluent output.</li>
+              <li>Use the Vandalizer exercise to distinguish ground-truth accuracy from replication.</li>
+              <li>Show OCR quality and schema design as upstream constraints on extraction quality.</li>
+              <li>Demonstrate multiple-pass consensus as a practical reproducibility test.</li>
+              <li>Shift to provenance with the NSF solicitation example and require source traceability.</li>
+              <li>Use a short context-for-trust setup to show what makes an analytics summary safer: reporting rules, source table, template, and human review.</li>
+              <li>Close with the final reporting exercise and then the adoption decision framework: what to automate, augment, or leave alone.</li>
             </ol>
           </article>
 
           <article class="course-module module-full">
             <span class="tag">Decision aid</span>
-            <h3>A quick rule for choosing the next layer</h3>
+            <h3>What context should do before a summary is shared</h3>
             <ul class="module-points">
-              <li>If the job is mostly wording and tone, start with instructions, examples, and templates.</li>
-              <li>If the job depends on a current policy or reference, add the smallest trusted file set that answers it.</li>
-              <li>If the job depends on live institutional facts, move to retrieval or SQL only after governance and permissions are clear.</li>
-              <li>If the job changes records, sends approvals, or creates risk, add a human gate before adding more automation.</li>
+              <li>Define the reporting period, metric rules, and scope so the model cannot invent them.</li>
+              <li>Provide the actual table, query result, or trusted source extract behind the summary request.</li>
+              <li>Use a template that separates directly supported facts from interpretation.</li>
+              <li>Keep a human review step whenever attribution, causality, anomaly explanation, or institutional judgment is involved.</li>
+              <li>If a claim cannot be traced to visible evidence, it is not ready to send.</li>
             </ul>
           </article>
         </section>
 
         <section id="example-practice" class="content-block reveal">
           <p class="eyebrow">Example and activity</p>
-          <h2 class="section-heading section-heading-wide">Map the stack against a real institutional workflow.</h2>
+          <h2 class="section-heading section-heading-wide">Use experiments and provenance checks to make trust visible.</h2>
           <div class="module-grid">
             <article class="course-module">
               <span class="tag">Worked example</span>
-              <h3>Building an AI-assisted research metrics report</h3>
+              <h3>Turn Vandalizer into an evaluation lab</h3>
               <p>
-                Imagine your office needs to produce a quarterly research
-                activity report that combines HERD expenditure data, proposal
-                and award counts from your eRA system, publication metrics from
-                a bibliometric database, and narrative context from department
-                leads. Today, an analyst pulls from four or five systems and
-                manually reconciles the numbers in a spreadsheet.
+                Rather than demoing extraction as magic, use the Vandalizer to
+                compare clean versus scanned PDFs, models, schema enforcement,
+                and repeated runs. Participants can see how accuracy changes
+                when one variable moves at a time.
               </p>
               <p class="module-follow">
-                With layered context, the workflow can combine role
-                instructions that define reporting standards, a report
-                template, SQL queries against the data warehouse, retrieved
-                publication data, and a human-review gate for narrative
-                interpretation and anomaly resolution.
+                This makes the session feel empirical. The tool matters less
+                than the method: define the comparison, hold the rest steady,
+                and measure what changes.
               </p>
             </article>
 
             <article class="course-module">
-              <span class="tag">What to point out</span>
-              <h3>What each layer contributes in the example</h3>
+              <span class="tag">Institutional example</span>
+              <h3>Quarterly research metrics reporting still needs evidence</h3>
               <ul class="module-points">
-                <li>The role instruction defines reporting conventions, data handling rules, and escalation boundaries.</li>
-                <li>The task prompt specifies the reporting period, metrics, and output format.</li>
-                <li>The template keeps the report structure consistent across quarters.</li>
-                <li>The SQL queries pull current figures from the institutional data warehouse.</li>
-                <li>The retrieved publication data adds external metrics the warehouse does not hold.</li>
-                <li>The human-review rule catches anomalies, contextualizes outliers, and owns the narrative.</li>
+                <li>An AI summary can sound polished while using stale numbers, mismatching fiscal years, or inventing trends.</li>
+                <li>Trusted use requires validated source systems, explicit checks against those systems, and human review for anomalies.</li>
+                <li>This is the lead-in to the final exercise: some claims are directly supported, some are interpretive, and some have no provenance at all.</li>
               </ul>
             </article>
           </div>
 
           <article class="course-module module-full">
             <span class="tag">Hands-on exercise</span>
-            <h3>Ask participants to map their own context stack</h3>
+            <h3>Four experiments participants can run</h3>
             <ol class="module-points">
-              <li>Choose a real workflow from your institution that people are tempted to automate.</li>
-              <li>Write the smallest prompt that describes the task.</li>
-              <li>List what other context the model would need to be genuinely useful.</li>
-              <li>Separate that context into layers: instructions, examples, files, tools, retrieval, and human escalation.</li>
-              <li>Decide which layers are available now, which ones are unsafe, and which ones need governance work first.</li>
+              <li>Compare extraction from a clean digital PDF with a scanned version and note how OCR affects the ceiling.</li>
+              <li>Run the same task with different models and look for agreement, divergence, and failure modes.</li>
+              <li>Test structured outputs against free-form outputs and note where schemas prevent or surface errors.</li>
+              <li>Repeat the same extraction multiple times and use consensus or disagreement as a reproducibility signal.</li>
+            </ol>
+          </article>
+
+          <article class="course-module module-full">
+            <span class="tag">Provenance exercise</span>
+            <h3>Ask where the answer came from</h3>
+            <ul class="module-points">
+              <li>Use the NSF solicitation workflow to surface deadlines, eligibility rules, page limits, special conditions, and budget requirements.</li>
+              <li>Pause before extraction and ask participants what would be easy to miss or misread by hand.</li>
+              <li>After extraction, require every important field to trace back to the exact passage, page, or section that supports it.</li>
+              <li>If a value cannot be traced, treat it as unverified and not ready to drive a workflow.</li>
+            </ul>
+          </article>
+
+          <article class="course-module module-full">
+            <span class="tag">Final interactive demo</span>
+            <h3>Can you defend this number?</h3>
+            <p>
+              End with a tiny two-year research metrics table and a handful of
+              AI-generated claims. Ask the room which statements they would
+              feel safe sending to leadership without checking. The point is to
+              separate claims that are directly supported from claims that are
+              interpretive, false, or missing provenance.
+            </p>
+            <ol class="module-points">
+              <li><strong>0:00-0:30</strong> Show the mini table and frame it as a dashboard snapshot plus an AI-drafted leadership summary.</li>
+              <li><strong>0:30-1:30</strong> Read four claims aloud and ask for a quick vote on which ones are safe to send as written.</li>
+              <li><strong>1:30-3:00</strong> Reveal the answer key: two claims are directly supported, one is contradicted by the numbers, and one has no provenance.</li>
+              <li><strong>3:00-4:00</strong> Ask what additional source evidence or review would be required before approving the risky claims.</li>
+              <li><strong>4:00-5:00</strong> Bridge to the adoption framework: supported low-stakes outputs may be automatable, checked summaries are augment, and anything without traceability belongs in leave alone.</li>
             </ol>
           </article>
 
@@ -260,27 +280,27 @@
             <span class="tag">Discussion prompt</span>
             <h3>Questions to ask participants</h3>
             <ul class="module-points">
-              <li>Which analytics or reporting workflows at your institution only need a better prompt or template?</li>
-              <li>Which ones need trusted data sources or retrieval before the output could be useful?</li>
-              <li>Which workflows would become risky the moment the system could write back to a production database or send a report?</li>
-              <li>Where should an analyst remain part of the context stack rather than outside it?</li>
-              <li>When would AI add value beyond what your existing BI dashboard or SQL query already delivers?</li>
+              <li>What counts as ground truth in one of your real workflows?</li>
+              <li>Where would sampling, reruns, or automated consistency checks add confidence?</li>
+              <li>Which outputs need source traceability before staff can act on them?</li>
+              <li>Where is AI helpful as a drafting assistant, and where does auditability force human ownership?</li>
+              <li>Which tasks at your institution are best framed as automate, augment, or leave alone?</li>
             </ul>
           </article>
         </section>
 
         <section id="facilitation" class="content-block reveal">
           <p class="eyebrow">Facilitation support</p>
-          <h2 class="section-heading">Keep every layer connected to trust and review.</h2>
+          <h2 class="section-heading">Keep the conversation anchored in evidence, not confidence.</h2>
           <article class="course-module module-full">
             <span class="tag">Speaker notes</span>
             <h3>Talking points for the presenter</h3>
             <ul class="module-points">
-              <li>Keep reminding participants that prompting is not the whole system.</li>
-              <li>Use the phrase "thin layer first" to normalize incremental design.</li>
-              <li>Show that some workflows improve more from templates and examples than from more model sophistication.</li>
-              <li>Stress that tools and retrieval increase power, but also increase the need for permissions, logging, and review.</li>
-              <li>Connect every layer back to trust: what is this layer allowed to influence, and who owns it?</li>
+              <li>Keep returning to the question: what would count as evidence that this output is right?</li>
+              <li>Emphasize that OCR quality and data-model design are upstream quality controls, not optional polish.</li>
+              <li>When participants ask which model is best, redirect to evaluation design, provenance, and auditability.</li>
+              <li>Use the bench-science analogy for replication because this audience already understands controlled variation and repeated measures.</li>
+              <li>Treat context as a supporting design choice: it helps only when it makes the resulting summary easier to verify and defend.</li>
             </ul>
           </article>
 
@@ -301,10 +321,11 @@
             <span class="tag">Workshop close</span>
             <h3>Wrap-up and takeaway</h3>
             <p>
-              This is the final session. Close with the adoption decision
-              framework — what to automate, what to augment, and what to
-              leave alone — plus discussion, REACH cross-references, and
-              the Sequita callback: if you can audit it, you can act on it.
+              This is the final session. Close by reinforcing four takeaways:
+              check accuracy against evidence, treat reproducibility as a
+              design requirement, expect provenance for high-stakes answers,
+              and use automate, augment, or leave alone only after
+              auditability is clear.
             </p>
           </article>
         </section>
@@ -318,8 +339,10 @@
             <p>
               A Reveal.js slide outline is available for live delivery,
               workshop rehearsal, and follow-up refinement. It should remain a
-              condensed version of the framing, layer map, worked example,
-              decision aid, and exercise documented here.
+              condensed version of the lifecycle framing, Vandalizer
+              evaluation exercises, provenance activity, short
+              context-for-trust setup, final analytics demo, and adoption
+              decision framework documented here.
             </p>
             <div class="hero-actions module-actions">
               <a class="button" href="slides-putting-it-to-work.html">Launch deck</a>

--- a/docs/slides-putting-it-to-work.html
+++ b/docs/slides-putting-it-to-work.html
@@ -373,53 +373,6 @@
           </div>
         </section>
 
-        <!-- DETECTING AI-GENERATED CONTENT -->
-        <section>
-          <p class="slide-kicker">Detection</p>
-          <h2>Can you tell if AI wrote it?</h2>
-          <div class="slide-split">
-            <div class="split-text">
-              <ul>
-                <li>NIH is actively using AI detection tools on grant applications</li>
-                <li>Detection tools (GPTZero, Originality.ai, Turnitin) are improving but imperfect — false positives happen</li>
-                <li>Stylistic markers: unnaturally even tone, hedging phrases ("It's important to note that..."), lack of specific institutional voice</li>
-                <li>The best defense isn't evading detection — it's genuine human authorship with AI assistance</li>
-              </ul>
-            </div>
-            <div class="split-text" style="flex: 0 0 40%;">
-              <div class="slide-card dark" style="margin-top:0;">
-                <span class="slide-label">When you're the reviewer</span>
-                <ul style="font-size:0.7rem;">
-                  <li>Subcontractor deliverables and consultant reports</li>
-                  <li>Student-submitted progress reports</li>
-                  <li>Subawardee compliance documentation</li>
-                  <li>Letters of support and collaboration statements</li>
-                </ul>
-                <p style="font-size:0.65rem; color:var(--muted); margin-top:0.3rem;">If it reads too smooth and says nothing specific, ask questions.</p>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <!-- GRANTED LESSONS (from workshop deck) -->
-        <section>
-          <p class="slide-kicker">Lessons learned</p>
-          <h2>The GRANTED project</h2>
-          <div class="slide-split">
-            <div class="split-img">
-              <img src="https://ai4ra.uidaho.edu/wp-content/uploads/2025/11/partnership.png" alt="GRANTED partnership — University of Idaho and Southern Utah University" />
-            </div>
-            <div class="split-text">
-              <ul>
-                <li>What the AI4RA NSF project revealed about deploying AI across institutions</li>
-                <li>Shared data infrastructure matters more than model choice</li>
-                <li>Governance work has to precede automation work</li>
-                <li>Cross-institutional interoperability requires shared schemas, not just shared tools</li>
-              </ul>
-            </div>
-          </div>
-        </section>
-
         <!-- WORKED EXAMPLE (from existing module) -->
         <section>
           <p class="slide-kicker">Worked example</p>
@@ -436,70 +389,134 @@
           </p>
         </section>
 
-        <!-- OPENING FRAME (from existing module) -->
+        <!-- CONTEXT FOR TRUST -->
         <section>
-          <p class="slide-kicker">Opening frame</p>
-          <h2>Your data is already layered — context engineering makes it explicit</h2>
-          <p>
-            HERD data in one system, publication metrics in another, eRA
-            records somewhere else, and BI dashboards pulling it together.
-            Context engineering is how AI works with institutional data where
-            it actually lives — the same integration challenge you already
-            solve for analytics and reporting.
-          </p>
+          <p class="slide-kicker">Before you send it</p>
+          <h2>What context makes a summary safer?</h2>
+          <div class="slide-split">
+            <div class="split-text">
+              <ul>
+                <li>Define the reporting period and metric rules so the model does not invent them.</li>
+                <li>Give the model the actual source table or query output, not a vague request for a narrative.</li>
+                <li>Use a template that separates directly supported facts from interpretation.</li>
+                <li>Keep a human review step for attribution, causality, anomalies, and edge cases.</li>
+              </ul>
+            </div>
+            <div class="split-text" style="flex: 0 0 40%;">
+              <div class="slide-card dark" style="margin-top:0;">
+                <span class="slide-label">What context should do</span>
+                <ul style="font-size:0.7rem;">
+                  <li>Reduce ambiguity about definitions</li>
+                  <li>Expose the source behind each number</li>
+                  <li>Make each claim easier to check</li>
+                  <li>Set clear escalation boundaries</li>
+                </ul>
+              </div>
+            </div>
+          </div>
         </section>
 
-        <!-- CONTEXT STACK (from existing module) -->
-        <section>
-          <p class="slide-kicker">The stack</p>
-          <h2>A practical context stack</h2>
-          <ul>
-            <li>System or role instructions</li>
-            <li>Task prompt</li>
-            <li>Examples and templates</li>
-            <li>Files and documents</li>
-            <li>Tools and actions</li>
-            <li>Retrieved and structured institutional data</li>
-          </ul>
-        </section>
-
-        <!-- WHAT EACH LAYER CONTRIBUTES (from existing module) -->
-        <section>
-          <p class="slide-kicker">What to teach</p>
-          <h2>What each layer contributes</h2>
-          <ul>
-            <li>Instructions set tone, caution, and escalation boundaries</li>
-            <li>The prompt defines the current task and output</li>
-            <li>Templates keep responses consistent</li>
-            <li>Policy documents provide institutional authority</li>
-            <li>Retrieved tables add current operational detail</li>
-            <li>Human review protects edge cases and exceptions</li>
-          </ul>
-        </section>
-
-        <!-- DECISION RULE (from existing module) -->
+        <!-- DECISION RULE -->
         <section>
           <p class="slide-kicker">Decision rule</p>
-          <h2>Use the thinnest layer that gets the job done</h2>
-          <p>
-            If a template and a clearer prompt solve the problem, stop there.
-            If a trusted PDF is enough, do not jump straight to retrieval. If
-            the task depends on local judgment, the right layer may be human
-            escalation instead of more automation.
+          <h2>Use the thinnest context that preserves traceability</h2>
+          <ul>
+            <li>If a claim is directly visible in a trusted table, AI can help draft the wording.</li>
+            <li>If a claim depends on joins, business rules, or interpretation, show the sources and keep a human in the loop.</li>
+            <li>If a claim cannot be traced to a source, it is not ready to send.</li>
+            <li>Context is useful only when it makes the output more defensible.</li>
+          </ul>
+          <p class="slide-callout">
+            That is the test in the next exercise: which claims survive once
+            you ask for evidence?
           </p>
         </section>
 
-        <!-- EXERCISE (from existing module) -->
+        <!-- FINAL ANALYTICS DEMO -->
         <section>
-          <p class="slide-kicker">Exercise</p>
-          <h2>Have participants map their own stack</h2>
-          <ul>
-            <li>Pick one workflow people want to automate</li>
-            <li>Write the smallest useful prompt</li>
-            <li>List the other context needed for trust</li>
-            <li>Sort it into layers</li>
-            <li>Mark what is ready now and what still needs governance work</li>
-          </ul>
+          <p class="slide-kicker">Final demo</p>
+          <h2>Can you defend this number?</h2>
+          <div class="slide-split">
+            <div class="split-text">
+              <div class="slide-card" style="margin-top:0;">
+                <span class="slide-label">Mini reporting table</span>
+                <p style="font-size:0.68rem; margin:0.3rem 0 0.55rem;">
+                  Prompt: "Write a 3-sentence leadership summary from this
+                  table."
+                </p>
+                <table style="width:100%; border-collapse:collapse; font-size:0.68rem;">
+                  <thead>
+                    <tr>
+                      <th style="text-align:left; border-bottom:1px solid rgba(25,25,25,0.18); padding:0.35rem 0.35rem 0.35rem 0;">Metric</th>
+                      <th style="text-align:right; border-bottom:1px solid rgba(25,25,25,0.18); padding:0.35rem;">FY2023</th>
+                      <th style="text-align:right; border-bottom:1px solid rgba(25,25,25,0.18); padding:0.35rem 0;">FY2024</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td style="padding:0.35rem 0.35rem 0.35rem 0; border-bottom:1px solid rgba(25,25,25,0.08);">Proposals submitted</td>
+                      <td style="text-align:right; padding:0.35rem; border-bottom:1px solid rgba(25,25,25,0.08);">108</td>
+                      <td style="text-align:right; padding:0.35rem 0; border-bottom:1px solid rgba(25,25,25,0.08);">128</td>
+                    </tr>
+                    <tr>
+                      <td style="padding:0.35rem 0.35rem 0.35rem 0; border-bottom:1px solid rgba(25,25,25,0.08);">Awards received</td>
+                      <td style="text-align:right; padding:0.35rem; border-bottom:1px solid rgba(25,25,25,0.08);">39</td>
+                      <td style="text-align:right; padding:0.35rem 0; border-bottom:1px solid rgba(25,25,25,0.08);">41</td>
+                    </tr>
+                    <tr>
+                      <td style="padding:0.35rem 0.35rem 0.35rem 0; border-bottom:1px solid rgba(25,25,25,0.08);">Award dollars</td>
+                      <td style="text-align:right; padding:0.35rem; border-bottom:1px solid rgba(25,25,25,0.08);">$10.8M</td>
+                      <td style="text-align:right; padding:0.35rem 0; border-bottom:1px solid rgba(25,25,25,0.08);">$12.4M</td>
+                    </tr>
+                    <tr>
+                      <td style="padding:0.35rem 0.35rem 0.35rem 0;">Publications linked to awards</td>
+                      <td style="text-align:right; padding:0.35rem;">61</td>
+                      <td style="text-align:right; padding:0.35rem 0;">67</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div class="split-text" style="flex: 0 0 46%;">
+              <div class="slide-card dark" style="margin-top:0;">
+                <span class="slide-label">Audience prompt</span>
+                <p style="font-size:0.7rem; margin-top:0.3rem;">
+                  Which claims would you feel safe sending to leadership right
+                  now?
+                </p>
+                <ol style="font-size:0.68rem; margin:0.45rem 0 0; padding-left:1.1rem;">
+                  <li style="margin-bottom:0.4rem;">
+                    Proposal volume grew 18.5% year over year.
+                    <span class="fragment" style="display:block; color:#9be564; margin-top:0.12rem;">Supported: 128 vs 108.</span>
+                  </li>
+                  <li style="margin-bottom:0.4rem;">
+                    Award dollars rose 14.8%, from $10.8M to $12.4M.
+                    <span class="fragment" style="display:block; color:#9be564; margin-top:0.12rem;">Supported: both values are visible in the table.</span>
+                  </li>
+                  <li style="margin-bottom:0.4rem;">
+                    The stronger proposal pipeline improved the award conversion rate.
+                    <span class="fragment" style="display:block; color:#ff9e80; margin-top:0.12rem;">Not supported: the conversion rate fell from 36.1% to 32.0%.</span>
+                  </li>
+                  <li>
+                    Engineering drove most of the growth.
+                    <span class="fragment" style="display:block; color:#ffd54f; margin-top:0.12rem;">No provenance: nothing here identifies discipline or source breakdown.</span>
+                  </li>
+                </ol>
+              </div>
+            </div>
+          </div>
+          <p class="slide-callout fragment">
+            Only claims 1 and 2 are defensible from the visible evidence. The
+            rest need either correction or additional source traceability.
+          </p>
+          <aside class="notes">
+            Five-minute run:
+            1. Say: "Pretend this is the last slide before a leadership update and AI drafted the narrative for you."
+            2. Ask the room to vote, by hand, on which claims they would send as written.
+            3. Reveal the fragments one by one and make them justify their choices from the visible evidence.
+            4. Ask what evidence they would need before approving claims 3 and 4.
+            5. Bridge to the next slide: if a human still needs to validate and defend the summary, that is augment. If you cannot trace the claim at all, leave it alone.
+          </aside>
         </section>
 
         <!-- FROM DATA TO ACTION (from workshop deck) -->
@@ -532,11 +549,11 @@
           <p class="slide-kicker">Discussion</p>
           <h2>What do you need at your institution?</h2>
           <ul>
-            <li>Which analytics or reporting workflows only need better prompts or templates?</li>
-            <li>Which ones need trusted data sources or retrieval before they are useful?</li>
-            <li>Which become risky once the system can write to production or send a report?</li>
-            <li>Where should an analyst remain part of the context stack?</li>
-            <li>When would AI add value beyond what your existing BI dashboard or SQL query already delivers?</li>
+            <li>Which dashboard claims at your institution would you send to leadership without manual checking?</li>
+            <li>What counts as ground truth in one of your real analytics workflows?</li>
+            <li>Where would reruns, sampling, or automated consistency checks add confidence?</li>
+            <li>Which outputs need source traceability before staff can act on them?</li>
+            <li>Which tasks are best framed as automate, augment, or leave alone?</li>
           </ul>
         </section>
 


### PR DESCRIPTION
## Summary
- update the Sessions tab copy for Barrie's module to center accuracy, reproducibility, and provenance
- align the Module 3 guide with the current deck flow, including the shorter context-for-trust setup and final analytics exercise
- revise the Module 3 slide deck to remove off-theme slides, streamline the context sequence, and add the "Can you defend this number?" interactive demo

## Testing
- verified edited pages load from the local docs server
- git diff --check