### PR TITLE
Session 3: back defend-this-number with synthetic corpus, split scale slide

### DIFF
--- a/docs/module-context-layers.html
+++ b/docs/module-context-layers.html
@@ -267,11 +267,19 @@
               separate claims that are directly supported from claims that are
               interpretive, false, or missing provenance.
             </p>
+            <p>
+              Every figure on the table is derived from the AI4RA synthetic
+              sponsored-research corpus, so each cell traces back to a field in
+              <code>records/proposals.json</code>, <code>awards.json</code>, or
+              <code>publications.json</code>. That is the payoff: if a
+              participant presses on a number, the presenter can literally open
+              the JSON and point to the row that produced it.
+            </p>
             <ol class="module-points">
               <li><strong>0:00-0:30</strong> Show the mini table and frame it as a dashboard snapshot plus an AI-drafted leadership summary.</li>
               <li><strong>0:30-1:30</strong> Read four claims aloud and ask for a quick vote on which ones are safe to send as written.</li>
               <li><strong>1:30-3:00</strong> Reveal the answer key: two claims are directly supported, one is contradicted by the numbers, and one has no provenance.</li>
-              <li><strong>3:00-4:00</strong> Ask what additional source evidence or review would be required before approving the risky claims.</li>
+              <li><strong>3:00-4:00</strong> Ask what additional source evidence or review would be required before approving the risky claims. Mention that the provenance-trap claim is defeated by a one-field lookup in <code>awards.json</code>.</li>
               <li><strong>4:00-5:00</strong> Bridge to the adoption framework: supported low-stakes outputs may be automatable, checked summaries are augment, and anything without traceability belongs in leave alone.</li>
             </ol>
           </article>

--- a/docs/slides-putting-it-to-work.html
+++ b/docs/slides-putting-it-to-work.html
@@ -448,33 +448,36 @@
                   <thead>
                     <tr>
                       <th style="text-align:left; border-bottom:1px solid rgba(25,25,25,0.18); padding:0.35rem 0.35rem 0.35rem 0;">Metric</th>
-                      <th style="text-align:right; border-bottom:1px solid rgba(25,25,25,0.18); padding:0.35rem;">FY2023</th>
-                      <th style="text-align:right; border-bottom:1px solid rgba(25,25,25,0.18); padding:0.35rem 0;">FY2024</th>
+                      <th style="text-align:right; border-bottom:1px solid rgba(25,25,25,0.18); padding:0.35rem;">FY2024</th>
+                      <th style="text-align:right; border-bottom:1px solid rgba(25,25,25,0.18); padding:0.35rem 0;">FY2025</th>
                     </tr>
                   </thead>
                   <tbody>
                     <tr>
                       <td style="padding:0.35rem 0.35rem 0.35rem 0; border-bottom:1px solid rgba(25,25,25,0.08);">Proposals submitted</td>
-                      <td style="text-align:right; padding:0.35rem; border-bottom:1px solid rgba(25,25,25,0.08);">108</td>
-                      <td style="text-align:right; padding:0.35rem 0; border-bottom:1px solid rgba(25,25,25,0.08);">128</td>
+                      <td style="text-align:right; padding:0.35rem; border-bottom:1px solid rgba(25,25,25,0.08);">11</td>
+                      <td style="text-align:right; padding:0.35rem 0; border-bottom:1px solid rgba(25,25,25,0.08);">6</td>
                     </tr>
                     <tr>
                       <td style="padding:0.35rem 0.35rem 0.35rem 0; border-bottom:1px solid rgba(25,25,25,0.08);">Awards received</td>
-                      <td style="text-align:right; padding:0.35rem; border-bottom:1px solid rgba(25,25,25,0.08);">39</td>
-                      <td style="text-align:right; padding:0.35rem 0; border-bottom:1px solid rgba(25,25,25,0.08);">41</td>
+                      <td style="text-align:right; padding:0.35rem; border-bottom:1px solid rgba(25,25,25,0.08);">1</td>
+                      <td style="text-align:right; padding:0.35rem 0; border-bottom:1px solid rgba(25,25,25,0.08);">9</td>
                     </tr>
                     <tr>
-                      <td style="padding:0.35rem 0.35rem 0.35rem 0; border-bottom:1px solid rgba(25,25,25,0.08);">Award dollars</td>
-                      <td style="text-align:right; padding:0.35rem; border-bottom:1px solid rgba(25,25,25,0.08);">$10.8M</td>
-                      <td style="text-align:right; padding:0.35rem 0; border-bottom:1px solid rgba(25,25,25,0.08);">$12.4M</td>
+                      <td style="padding:0.35rem 0.35rem 0.35rem 0; border-bottom:1px solid rgba(25,25,25,0.08);">Award dollars obligated</td>
+                      <td style="text-align:right; padding:0.35rem; border-bottom:1px solid rgba(25,25,25,0.08);">$825K</td>
+                      <td style="text-align:right; padding:0.35rem 0; border-bottom:1px solid rgba(25,25,25,0.08);">$5.45M</td>
                     </tr>
                     <tr>
                       <td style="padding:0.35rem 0.35rem 0.35rem 0;">Publications linked to awards</td>
-                      <td style="text-align:right; padding:0.35rem;">61</td>
-                      <td style="text-align:right; padding:0.35rem 0;">67</td>
+                      <td style="text-align:right; padding:0.35rem;">7</td>
+                      <td style="text-align:right; padding:0.35rem 0;">13</td>
                     </tr>
                   </tbody>
                 </table>
+                <p style="font-size:0.55rem; color:rgba(25,25,25,0.55); margin:0.45rem 0 0; line-height:1.3;">
+                  Source: AI4RA synthetic sponsored-research corpus. Every cell traces to a field in <code style="font-size:0.55rem;">records/proposals.json</code>, <code style="font-size:0.55rem;">awards.json</code>, or <code style="font-size:0.55rem;">publications.json</code>.
+                </p>
               </div>
             </div>
             <div class="split-text" style="flex: 0 0 46%;">
@@ -486,20 +489,20 @@
                 </p>
                 <ol style="font-size:0.68rem; margin:0.45rem 0 0; padding-left:1.1rem;">
                   <li style="margin-bottom:0.4rem;">
-                    Proposal volume grew 18.5% year over year.
-                    <span class="fragment" style="display:block; color:#9be564; margin-top:0.12rem;">Supported: 128 vs 108.</span>
-                  </li>
-                  <li style="margin-bottom:0.4rem;">
-                    Award dollars rose 14.8%, from $10.8M to $12.4M.
+                    Award dollars obligated grew more than six-fold, from $825K to $5.45M.
                     <span class="fragment" style="display:block; color:#9be564; margin-top:0.12rem;">Supported: both values are visible in the table.</span>
                   </li>
                   <li style="margin-bottom:0.4rem;">
-                    The stronger proposal pipeline improved the award conversion rate.
-                    <span class="fragment" style="display:block; color:#ff9e80; margin-top:0.12rem;">Not supported: the conversion rate fell from 36.1% to 32.0%.</span>
+                    Publications linked to awards rose from 7 to 13.
+                    <span class="fragment" style="display:block; color:#9be564; margin-top:0.12rem;">Supported: both values are visible in the table.</span>
+                  </li>
+                  <li style="margin-bottom:0.4rem;">
+                    A growing proposal pipeline drove the surge in awards.
+                    <span class="fragment" style="display:block; color:#ff9e80; margin-top:0.12rem;">Contradicted: proposals submitted actually fell from 11 to 6. Awards lag submissions by a review cycle.</span>
                   </li>
                   <li>
-                    Engineering drove most of the growth.
-                    <span class="fragment" style="display:block; color:#ffd54f; margin-top:0.12rem;">No provenance: nothing here identifies discipline or source breakdown.</span>
+                    Industry sponsors powered most of the growth.
+                    <span class="fragment" style="display:block; color:#ffd54f; margin-top:0.12rem;">No provenance: the aggregate hides sponsor mix. Answer lives in <code style="font-size:0.6rem;">awards.json · sponsor_code</code>, not the summary.</span>
                   </li>
                 </ol>
               </div>
@@ -516,6 +519,10 @@
             3. Reveal the fragments one by one and make them justify their choices from the visible evidence.
             4. Ask what evidence they would need before approving claims 3 and 4.
             5. Bridge to the next slide: if a human still needs to validate and defend the summary, that is augment. If you cannot trace the claim at all, leave it alone.
+
+            Provenance note: every cell on this table is derived from the AI4RA synthetic sponsored-research corpus. If a participant presses on a number, you can literally open the JSON: proposals submitted come from proposals.json (counting submission_deadline by FY), awards received and award dollars come from awards.json (award_received_date, total_obligated), publications linked come from publications.json (year, award_ids). That is what defensibility looks like in practice: a reporter can trace every figure to a field in a file.
+
+            Claim 4 callback: the corpus DOES contain an industry sponsor (Pharmakom SRA with Meyer), but it is one award out of nine in FY25. So "industry drove growth" is not just unprovable from the aggregate, it is wrong once you drop into sponsor_code. Good moment to point out that AI summaries often sound plausible AND are defeated by a single query against the source.
           </aside>
         </section>
 

--- a/docs/slides-putting-it-to-work.html
+++ b/docs/slides-putting-it-to-work.html
@@ -191,8 +191,44 @@
             <li>Design verification strategies proportional to the stakes</li>
           </ul>
           <p class="slide-callout">
-            Human verification of every record doesn't scale — when a pipeline processes thousands of documents, you need evaluation strategies: sampling, automated consistency checks, and reproducibility testing.
+            Human verification of every record doesn't scale.
           </p>
+        </section>
+
+        <!-- WHERE HUMAN VERIFICATION BREAKS DOWN -->
+        <section>
+          <p class="slide-kicker">Why it doesn't scale</p>
+          <h2>Where human verification breaks down</h2>
+          <p class="slide-note">Three shapes the bottleneck takes in real research-analytics workflows. Different axes, same conclusion.</p>
+          <div class="slide-grid">
+            <article class="slide-card accent">
+              <span class="slide-label">Batch extraction at volume</span>
+              <p style="font-size:0.72rem;">An overnight pipeline runs <strong>thousands of documents</strong> through OCR, extraction, and classification. Every proposal, award letter, or subaward agreement produces dozens of structured fields. Reading each one before anyone acts is a full headcount's worth of work — that never catches up.</p>
+            </article>
+            <article class="slide-card accent">
+              <span class="slide-label">Autonomous agents on live data</span>
+              <p style="font-size:0.72rem;">Agents crawl the data lakehouse making <strong>thousands of classification, join, and lookup decisions per second</strong>. Each decision looks reasonable in isolation. Humans never see the intermediate steps — only the summary — so a subtle drift compounds invisibly across millions of ops before anyone notices.</p>
+            </article>
+            <article class="slide-card accent">
+              <span class="slide-label">Continuous compliance triage</span>
+              <p style="font-size:0.72rem;">Every COI disclosure, cost transfer, and effort variance is auto-routed into <strong>clear, escalate, or review</strong>. A silent rule drift — a prompt tweak, a schema change, a new sponsor edge case — can redirect hundreds of cases into the wrong bucket before audit season catches it.</p>
+            </article>
+          </div>
+          <p class="slide-callout">
+            So the job stops being "review every output" and starts being "design the verification pipeline" — sampling, automated consistency checks, and reproducibility tests, scaled to match the throughput.
+          </p>
+          <aside class="notes">
+            The previous slide ended on a declarative punchline: human verification doesn't scale. This slide gives that punchline a body.
+
+            Why three examples rather than one: each is a different axis of "doesn't scale."
+            - Batch extraction = throughput (volume over time, one-off outputs you never revisit).
+            - Agents = speed and opacity (humans can't even observe the intermediate steps at line rate).
+            - Compliance triage = drift (a continuous stream where the rule itself can silently shift).
+
+            All three are live in research-admin workflows today. You probably know staff who do one of these by hand now and are being asked to automate.
+
+            Closing move: pivot to the hands-on exercise. The next slide introduces the Vandalizer evaluation experiment — the concrete version of "design the verification pipeline" for extraction.
+          </aside>
         </section>
 
         <!-- VANDALIZER EVALUATION EXERCISE -->


### PR DESCRIPTION
## Summary
- Replace the invented FY2023/FY2024 table on "Can you defend this number?" with real FY2024/FY2025 figures derived from the AI4RA synthetic sponsored-research corpus. Every cell traces to a field in `records/proposals.json`, `awards.json`, or `publications.json`. Claims and answer fragments rewritten to match; the provenance-trap claim now points at a one-field lookup in `awards.json · sponsor_code`. Module page and speaker notes updated to match.
- Split the "Human verification doesn't scale" callout out of the "Can you trust the output?" slide into a dedicated follow-on slide with three examples along different axes of scale: batch extraction at volume, autonomous agents on live data, and continuous compliance triage. Closing callout pivots to the verification-pipeline response (sampling, consistency checks, reproducibility).

## Test plan
- [ ] Preview `docs/slides-putting-it-to-work.html` and walk from "Can you trust the output?" through the new scale slide into the Vandalizer evaluation exercise — timing and narrative flow feel right.
- [ ] Preview "Can you defend this number?" and confirm the table fits, the source footnote is legible, and the four claim fragments reveal cleanly.
- [ ] Open `docs/module-context-layers.html` and confirm the updated "Can you defend this number?" description reads cleanly alongside the other module cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)